### PR TITLE
add toSnake function and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Manipulator::make('camelCase')->camelToSnake();
 // camel_case
 ```
 
+### toSnake
+```php
+Manipulator::make('camelCase')->toSnake();
+// camel_case
+```
+
 ### camelToClass
 ```php
 Manipulator::make('className')->camelToClass();

--- a/README.md
+++ b/README.md
@@ -291,6 +291,12 @@ Manipulator::make('hello my name is inigo montoya, you killed my father, prepare
 // Hello My Name Is Inigo Montoya, You Killed My Father, Prepare To Die!
 ```
 
+```php
+// if the string is Camel Case, the first letter should be uppercase, but it should not do anything to the rest of the string.
+Manipulator::make('aCamelCaseString')->ucAll();
+// ACamelCaseString
+```
+
 ## Contribute
 Contributions are very welcome!
 

--- a/README.md
+++ b/README.md
@@ -284,6 +284,13 @@ Manipulator::make('hello')->toUpper()->reverse();
 // OLLEH
 ```
 
+## ucAll
+
+```php
+Manipulator::make('hello my name is inigo montoya, you killed my father, prepare to die!')->ucAll();
+// Hello My Name Is Inigo Montoya, You Killed My Father, Prepare To Die!
+```
+
 ## Contribute
 Contributions are very welcome!
 

--- a/src/Manipulator.php
+++ b/src/Manipulator.php
@@ -585,11 +585,15 @@ class Manipulator
     protected function ucAll()
     {
         $temp = preg_split('/(\W)/', $this->string, -1, PREG_SPLIT_DELIM_CAPTURE);
-        if (count($temp) > 1) {
-            foreach ($temp as $key => $word) {
-                $temp[$key] = ucfirst(strtolower($word));
-            }
+
+        if (count($temp) == 1) {
+            return $this;
         }
+
+        foreach ($temp as $key => $word) {
+            $temp[$key] = ucfirst(strtolower($word));
+        }
+        
         return new static(join('', $temp));
     }
 }

--- a/src/Manipulator.php
+++ b/src/Manipulator.php
@@ -574,9 +574,7 @@ class Manipulator
             $newModified .= ctype_upper($character) ? '_' . $character : $character;
         }
 
-        $newModified = new static(mb_strtolower($newModified));
-
-        return new static($newModified->replace(' ', '_')->replace('-', '_')->replace('__', '_')->toString());
+        return (new static($newModified))->toLower()->replace(' ', '_')->replace('-', '_')->replace('__', '_');
     }
 
     /**

--- a/src/Manipulator.php
+++ b/src/Manipulator.php
@@ -30,22 +30,22 @@ class Manipulator
         return $this->string;
     }
 
-	/**
-	 * Append to the string.
-	 *
-	 * @param string $string
-	 * @return object|Manipulator
-	 */
+    /**
+     * Append to the string.
+     *
+     * @param string $string
+     * @return object|Manipulator
+     */
     public function append(string $string) : Manipulator
     {
         return new static($this->string . $string);
     }
 
-	/**
-	 * Convert a camel-case string to snake-case.
-	 *
-	 * @return object|Manipulator
-	 */
+    /**
+     * Convert a camel-case string to snake-case.
+     *
+     * @return object|Manipulator
+     */
     public function camelToSnake() : Manipulator
     {
         $modifiedString = '';
@@ -57,14 +57,14 @@ class Manipulator
         return new static(mb_strtolower($modifiedString));
     }
 
-	/**
-	 * Convert a camel-case string to class-case.
-	 *
-	 * @return object|Manipulator
-	 */
+    /**
+     * Convert a camel-case string to class-case.
+     *
+     * @return object|Manipulator
+     */
     public function camelToClass() : Manipulator
     {
-	    return new static($this->capitalize()->toString());
+        return new static($this->capitalize()->toString());
     }
 
     /**
@@ -88,40 +88,40 @@ class Manipulator
         return new static(trim(mb_convert_case($this->string, MB_CASE_TITLE)));
     }
 
-	/**
-	 * Perform an action on each character in the string.
-	 *
-	 * @param $closure
-	 * @return object|Manipulator
-	 */
+    /**
+     * Perform an action on each character in the string.
+     *
+     * @param $closure
+     * @return object|Manipulator
+     */
     public function eachCharacter(\Closure $closure) : Manipulator
     {
-	    $modifiedString = '';
+        $modifiedString = '';
 
-	    foreach (str_split($this->string) as $character) {
-			$modifiedString .= $closure($character);
-		}
+        foreach (str_split($this->string) as $character) {
+            $modifiedString .= $closure($character);
+        }
 
-		return new static($modifiedString);
+        return new static($modifiedString);
     }
 
-	/**
-	 * Perform an action on each word in the string.
-	 *
-	 * @param $closure
-	 * @param bool $preserveSpaces
-	 * @return object|Manipulator
-	 */
+    /**
+     * Perform an action on each word in the string.
+     *
+     * @param $closure
+     * @param bool $preserveSpaces
+     * @return object|Manipulator
+     */
     public function eachWord(\Closure $closure, bool $preserveSpaces = false) : Manipulator
     {
-	    $modifiedString = '';
+        $modifiedString = '';
 
-	    foreach(explode(' ', $this->string) as $word) {
-		    $modifiedString .= $closure($word);
-		    $modifiedString .= $preserveSpaces ? ' ' : '';
-	    }
+        foreach (explode(' ', $this->string) as $word) {
+            $modifiedString .= $closure($word);
+            $modifiedString .= $preserveSpaces ? ' ' : '';
+        }
 
-	    return new static(trim($modifiedString));
+        return new static(trim($modifiedString));
     }
 
     /**
@@ -133,7 +133,7 @@ class Manipulator
     {
         $modifiedString = $this->trimEnd();
 
-        if(mb_substr($modifiedString, -1) === 's') {
+        if (mb_substr($modifiedString, -1) === 's') {
             $modifiedString .= '\'';
         } else {
             $modifiedString .= '\'s';
@@ -228,10 +228,10 @@ class Manipulator
          * Optional parameter to determine if a string
          * should be pluralized.
          */
-        if(!is_null($items)) {
+        if (!is_null($items)) {
             $count = is_numeric($items) ? $items : count($items);
 
-            if($count <= 1) {
+            if ($count <= 1) {
                 return $this;
             }
         }
@@ -283,13 +283,13 @@ class Manipulator
         $count = 1;
         $modifiedString = '';
 
-	    foreach(explode(' ', $this->string) as $word) {
-		    $modifiedString .= $count === $nth ? $closure($word) : $word;
-		    $modifiedString .= $preserveSpaces ? ' ' : '';
+        foreach (explode(' ', $this->string) as $word) {
+            $modifiedString .= $count === $nth ? $closure($word) : $word;
+            $modifiedString .= $preserveSpaces ? ' ' : '';
             $count++;
-	    }
+        }
 
-	    return new static(trim($modifiedString));
+        return new static(trim($modifiedString));
     }
 
     /**
@@ -315,7 +315,7 @@ class Manipulator
         $regEx  = "/";
         $regEx .= "[^\w\d";
 
-        foreach($exceptions as $exception) {
+        foreach ($exceptions as $exception) {
             $regEx .= "\\" . $exception;
         }
 
@@ -427,16 +427,16 @@ class Manipulator
         return new static($final);
     }
 
-	/**
-	 * Make a string L33t.
-	 *
-	 * @return object|Manipulator
-	 */
+    /**
+     * Make a string L33t.
+     *
+     * @return object|Manipulator
+     */
     public function toL33t() : Manipulator
     {
-	    return new static($this->eachCharacter(function($char) {
-		    return L33t::makeItL33t($char);
-	    })->toString());
+        return new static($this->eachCharacter(function ($char) {
+            return L33t::makeItL33t($char);
+        })->toString());
     }
 
     /**
@@ -558,5 +558,40 @@ class Manipulator
     public function urlEncode() : Manipulator
     {
         return new static(urlencode($this->string));
+    }
+
+    /**
+     * Return String in SnakeCase
+     * @return object|Manipulator
+     */
+    public function toSnake() : Manipulator
+    {
+        $newModified = null;
+
+        $this->string = lcfirst($this->ucAll());
+        
+        foreach (str_split($this->string, 1) as $character) {
+            $newModified .= ctype_upper($character) ? '_' . $character : $character;
+        }
+
+        $newModified = new static(mb_strtolower($newModified));
+
+        return new static($newModified->replace(' ', '_')->replace('-', '_')->replace('__', '_')->toString());
+    }
+
+    /**
+     * Returns string with each word is first letter capitalized
+     * except if it is camelCase (which is treated as one word)
+     * @return object|Manipulator
+     */
+    protected function ucAll()
+    {
+        $temp = preg_split('/(\W)/', $this->string, -1, PREG_SPLIT_DELIM_CAPTURE);
+        if (count($temp) > 1) {
+            foreach ($temp as $key => $word) {
+                $temp[$key] = ucfirst(strtolower($word));
+            }
+        }
+        return new static(join('', $temp));
     }
 }

--- a/src/Manipulator.php
+++ b/src/Manipulator.php
@@ -587,7 +587,7 @@ class Manipulator
         $temp = preg_split('/(\W)/', $this->string, -1, PREG_SPLIT_DELIM_CAPTURE);
 
         if (count($temp) == 1) {
-            return $this;
+            return self::make(ucfirst(implode('', $temp)));
         }
 
         foreach ($temp as $key => $word) {

--- a/src/Manipulator.php
+++ b/src/Manipulator.php
@@ -574,7 +574,7 @@ class Manipulator
             $newModified .= ctype_upper($character) ? '_' . $character : $character;
         }
 
-        return (new static($newModified))->toLower()->replace(' ', '_')->replace('-', '_')->replace('__', '_');
+        return self::make($newModified)->toLower()->replace(' ', '_')->replace('-', '_')->replace('__', '_');
     }
 
     /**

--- a/src/Manipulator.php
+++ b/src/Manipulator.php
@@ -582,7 +582,7 @@ class Manipulator
      * except if it is camelCase (which is treated as one word)
      * @return object|Manipulator
      */
-    protected function ucAll()
+    public function ucAll()
     {
         $temp = preg_split('/(\W)/', $this->string, -1, PREG_SPLIT_DELIM_CAPTURE);
 
@@ -593,7 +593,7 @@ class Manipulator
         foreach ($temp as $key => $word) {
             $temp[$key] = ucfirst(strtolower($word));
         }
-        
+
         return new static(join('', $temp));
     }
 }

--- a/tests/functions.php
+++ b/tests/functions.php
@@ -321,4 +321,10 @@ class Functions extends \PHPUnit_Framework_TestCase
         $string = Manipulator::make('This-is-dashed-case')->toSnake();
         $this->assertEquals('this_is_dashed_case', $string);
     }
+
+    public function test_toSnake_snake_case_string_in_snake_case()
+    {
+        $string = Manipulator::make('this_is_snake_case')->toSnake();
+        $this->assertEquals('this_is_snake_case', $string);
+    }
 }

--- a/tests/functions.php
+++ b/tests/functions.php
@@ -327,4 +327,10 @@ class Functions extends \PHPUnit_Framework_TestCase
         $string = Manipulator::make('this_is_snake_case')->toSnake();
         $this->assertEquals('this_is_snake_case', $string);
     }
+
+    public function test_ucAll_returns_string_with_each_word_ucfirst()
+    {
+        $string = Manipulator::make('hello my name is inigo montoya, you killed my father, prepare to die!')->ucAll();
+        $this->assertEquals('Hello My Name Is Inigo Montoya, You Killed My Father, Prepare To Die!', $string);
+    }
 }

--- a/tests/functions.php
+++ b/tests/functions.php
@@ -5,7 +5,6 @@ use TheStringler\Manipulator\Manipulator as Manipulator;
 
 class Functions extends \PHPUnit_Framework_TestCase
 {
-
     /**
      * @expectedException \TypeError
      */
@@ -242,43 +241,43 @@ class Functions extends \PHPUnit_Framework_TestCase
 
     public function test_that_a_camel_case_string_is_converted_to_class_case()
     {
-		$string = Manipulator::make('className')->camelToClass();
-	    $this->assertEquals($string, 'ClassName');
+        $string = Manipulator::make('className')->camelToClass();
+        $this->assertEquals($string, 'ClassName');
     }
 
     public function test_that_each_character_is_capitalized()
     {
-	    $string = Manipulator::make('hello')->eachCharacter(function($char) {
-		    return strtoupper($char);
-	    });
-	    $this->assertEquals($string, 'HELLO');
+        $string = Manipulator::make('hello')->eachCharacter(function ($char) {
+            return strtoupper($char);
+        });
+        $this->assertEquals($string, 'HELLO');
     }
 
-	public function test_that_each_character_is_reversed_spaces_not_preserved()
-	{
-		$string = Manipulator::make('hello moto')->eachWord(function($word) {
-			return strrev($word);
-		});
-		$this->assertEquals($string, 'ollehotom');
-	}
+    public function test_that_each_character_is_reversed_spaces_not_preserved()
+    {
+        $string = Manipulator::make('hello moto')->eachWord(function ($word) {
+            return strrev($word);
+        });
+        $this->assertEquals($string, 'ollehotom');
+    }
 
-	public function test_that_each_character_is_reversed_spaces_preserved()
-	{
-		$string = Manipulator::make('hello moto')->eachWord(function($word) {
-			return strrev($word);
-		}, true);
-		$this->assertEquals($string, 'olleh otom');
-	}
+    public function test_that_each_character_is_reversed_spaces_preserved()
+    {
+        $string = Manipulator::make('hello moto')->eachWord(function ($word) {
+            return strrev($word);
+        }, true);
+        $this->assertEquals($string, 'olleh otom');
+    }
 
-	public function test_that_string_is_made_l33t()
-	{
-		$isL33t = Manipulator::make('Hack The Planet!')->toL33t()->toString();
-		$this->assertTrue(is_string($isL33t));
-	}
+    public function test_that_string_is_made_l33t()
+    {
+        $isL33t = Manipulator::make('Hack The Planet!')->toL33t()->toString();
+        $this->assertTrue(is_string($isL33t));
+    }
 
     public function test_that_nth_character_is_modified()
     {
-        $string = Manipulator::make('Wordpress')->nthCharacter(5, function($character) {
+        $string = Manipulator::make('Wordpress')->nthCharacter(5, function ($character) {
             return mb_strtoupper($character);
         });
         $this->assertEquals($string, 'WordPress');
@@ -286,9 +285,40 @@ class Functions extends \PHPUnit_Framework_TestCase
 
     public function test_that_nth_word_is_modified()
     {
-        $string = Manipulator::make('Oh hello there!')->nthWord(2, function($word) {
+        $string = Manipulator::make('Oh hello there!')->nthWord(2, function ($word) {
             return mb_strtoupper($word);
         });
         $this->assertEquals($string, 'Oh HELLO there!');
+    }
+    
+    public function test_toSnake_returns_camel_case_string_in_snake_case()
+    {
+        $string = Manipulator::make('thisIsCamelCaseString')->toSnake();
+        $this->assertEquals('this_is_camel_case_string', $string);
+    }
+
+    public function test_toSnake_one_word_capitalized_string_in_snake_case()
+    {
+        $string = Manipulator::make('This one word CAPITALIZED case')->toSnake();
+        $this->assertEquals('this_one_word_capitalized_case', $string);
+    }
+    
+    public function test_toSnake_returns_capital_case_string_in_snake_case()
+    {
+        $string = Manipulator::make('This Is Capital Case')->toSnake();
+        $this->assertEquals('this_is_capital_case', $string);
+    }
+
+
+    public function test_toSnake_returns_regular_string_in_snake_case()
+    {
+        $string = Manipulator::make('This is regular case')->toSnake();
+        $this->assertEquals('this_is_regular_case', $string);
+    }
+
+    public function test_toSnake_dash_separated_string_in_snake_case()
+    {
+        $string = Manipulator::make('This-is-dashed-case')->toSnake();
+        $this->assertEquals('this_is_dashed_case', $string);
     }
 }

--- a/tests/functions.php
+++ b/tests/functions.php
@@ -333,4 +333,10 @@ class Functions extends \PHPUnit_Framework_TestCase
         $string = Manipulator::make('hello my name is inigo montoya, you killed my father, prepare to die!')->ucAll();
         $this->assertEquals('Hello My Name Is Inigo Montoya, You Killed My Father, Prepare To Die!', $string);
     }
+
+    public function test_ucAll_returns_string_with_each_word_ucfirst_if_camel_case()
+    {
+        $string = Manipulator::make('aCamelCaseString')->ucAll();
+        $this->assertEquals('ACamelCaseString', $string);
+    }
 }


### PR DESCRIPTION
This appears to work, I wrote six tests to give potential strings that could be passed to Manipulator (all existing tests pass as well as new ones). 

My thinking is that having a method like `camelToSnake` means you have to know which case your string is in, which isn't as OOP as I would want to use.

Adding `toSnake` would suggest that you just pass any string to Manipulator...then if you want snake case you call `toSnake`. There could be some additional cases that I do not account for...but I think this is a decent start (albeit kind of quickly thrown together).

If there are additional cases that should be accounted for, let me know, and I will try to figure that out.