### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-  - 5.6
   - 7.0
   - 7.1
   - 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: php
+php:
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+  - nightly
+
+before_script:
+  - composer install
+
+script:
+  - ./vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,12 @@
         }
     ],
     "require": {
+        "php": ">=5.6",
         "doctrine/inflector": "^1.1"
     },
     "require-dev": {
-      "phpunit/phpunit": "^5.4"
+      "php": ">=5.6",
+      "phpunit/phpunit": "^5.7"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,12 @@
         }
     ],
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.0",
         "doctrine/inflector": "^1.1"
     },
     "require-dev": {
-      "php": ">=5.6",
-      "phpunit/phpunit": "^5.7"
+      "php": ">=7.0",
+      "phpunit/phpunit": "^6.5"
     },
     "autoload": {
         "psr-4": {

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -1,9 +1,10 @@
 <?php
-namespace TheStringler\Tests;
+namespace TheStringler\Manipulator\Tests;
 
 use TheStringler\Manipulator\Manipulator as Manipulator;
+use PHPUnit\Framework\TestCase;
 
-class Functions extends \PHPUnit_Framework_TestCase
+class FunctionsTest extends TestCase
 {
 
     /**


### PR DESCRIPTION
# Changed log

- Add Travis build. Please see the latest [Travis build status](https://travis-ci.org/peter279k/the-stringler/builds/343234596).
- Test the PHP ```5.6```, ```7.0```, ```7.1``` and ```7.2``` in Travis build.
- Set the correct test suite name. That is, replacing the ```Functions``` with ```FunctionsTest``` method name.